### PR TITLE
Add Activating Tanzu services on VMware Cloud on AWS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Examples are provided for the following:
 - Cloud Proxy for vRealize Network Insight Cloud
 - Cloud Proxy for vRealize Automation Cloud
 - Cloud Extensibility Proxy for vRealize Automation Cloud
+- Activate Tanzu services on VMware Cloud on AWS
 
 **VMware vSphere**
 - vSphere Content Library

--- a/vmware-cloud/vmc-activate-tanzu-service/main.tf
+++ b/vmware-cloud/vmc-activate-tanzu-service/main.tf
@@ -1,0 +1,80 @@
+terraform {
+  required_providers {
+    restapi = {
+      source  = "Mastercard/restapi"
+      version = "1.16.2"
+    }
+  }
+}
+
+####################################
+# CSP API Client Configuration
+####################################
+provider "restapi" {
+  alias                = "csp"
+  uri                  = var.csp_uri
+  debug                = var.debug
+  write_returns_object = true
+
+  headers = {
+    Content-Type = "application/x-www-form-urlencoded"
+  }
+
+  create_method = "POST"
+}
+
+# Retreive CSP Access Token
+resource "restapi_object" "retrieve_access_token" {
+  provider     = restapi.csp
+  path         = "/csp/gateway/am/api/auth/api-tokens/authorize?refresh_token=${var.refresh_token}"
+  data         = ""
+  id_attribute = "expires_in"
+}
+
+####################################
+# VMC API Client Configuration
+####################################
+provider "restapi" {
+  alias                = "vmc"
+  uri                  = var.vmc_uri
+  debug                = var.debug
+  write_returns_object = true
+
+  headers = {
+    csp-auth-token = restapi_object.retrieve_access_token.api_data.access_token
+    Content-Type   = "application/json"
+  }
+}
+
+# Retreive SDDC Cluster ID
+resource "restapi_object" "get_sddc_cluster" {
+  depends_on    = [restapi_object.retrieve_access_token]
+  create_method = "GET"
+
+  provider = restapi.vmc
+  path     = "/vmc/api/orgs/${var.org_id}/sddcs/${var.sddc_id}"
+  data     = ""
+}
+
+# Store Cluster Id for use in the activation step
+locals {
+  cluster_id = [for cluster in jsondecode(restapi_object.get_sddc_cluster.api_response).resource_config.clusters : cluster.cluster_id if cluster.cluster_name == var.cluster_name][0]
+}
+
+output "debug_cluster_id" {
+  value = local.cluster_id
+}
+
+# Activate Tanzu service on SDDC Cluster
+resource "restapi_object" "activate_tanzu_service" {
+  depends_on    = [restapi_object.retrieve_access_token, local.cluster_id]
+  create_method = "POST"
+
+  provider = restapi.vmc
+  path     = "/api/wcp/v1/orgs/${var.org_id}/deployments/${var.sddc_id}/clusters/${local.cluster_id}/operations/enable-wcp"
+  data     = "{\"ingress_cidr\":[\"${var.ingress_cidr}\"],\"egress_cidr\": [\"${var.egress_cidr}\"],\"service_cidr\": \"${var.service_cidr}\",\"namespace_cidr\": [\"${var.namespace_cidr}\"]}"
+}
+
+output "tanzu_service_activation_task" {
+  value = restapi_object.activate_tanzu_service.api_data
+}

--- a/vmware-cloud/vmc-activate-tanzu-service/terraform.tfvars.example
+++ b/vmware-cloud/vmc-activate-tanzu-service/terraform.tfvars.example
@@ -1,0 +1,10 @@
+
+debug           = false
+refresh_token   = "FILL_ME_IN"
+org_id          = "FILL_ME_IN"
+sddc_id         = "FILL_ME_IN"
+cluster_name    = "Cluster-1"
+ingress_cidr    = "10.10.0.0/23"
+egress_cidr     = "10.10.2.0/23"
+service_cidr    = "10.96.0.0/24"
+namespace_cidr  = "10.10.4.0/23"

--- a/vmware-cloud/vmc-activate-tanzu-service/variables.tf
+++ b/vmware-cloud/vmc-activate-tanzu-service/variables.tf
@@ -1,0 +1,59 @@
+variable "csp_uri" {
+  type        = string
+  description = "Base URL for VMware Cloud Service API endpoint"
+  default     = "https://console.cloud.vmware.com"
+}
+
+variable "vmc_uri" {
+  type        = string
+  description = "Base URL for VMware Cloud Console API endpoint"
+  default     = "https://vmc.vmware.com"
+}
+
+variable "debug" {
+  type        = bool
+  description = "Enable debugging"
+}
+
+variable "refresh_token" {
+  type        = string
+  description = "VMware Cloud Service Refresh Token"
+  sensitive   = true
+}
+
+variable "org_id" {
+  type        = string
+  description = "VMware Cloud on AWS Organization ID"
+  sensitive   = true
+}
+
+variable "sddc_id" {
+  type        = string
+  description = "VMware Cloud on AWS SDDC ID"
+  sensitive   = true
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of SDDC Cluser to activate Tanzu services"
+}
+
+variable "ingress_cidr" {
+  type        = string
+  description = "This block of addresses is allocated to receive inbound traffic through load-balancers to containers. The system allocates a destination NAT (DNAT) address from this pool for each namespace in the cluster, so a span of /23 or /26 should be adequate."
+}
+
+variable "egress_cidr" {
+  type        = string
+  description = "This block of addresses is allocated to outbound traffic from containers and guest clusters. The system allocates a source NAT (SNAT) IP address from this pool for each namespace in the cluster, so a span of /23 or /26 should be adequate."
+}
+
+variable "service_cidr" {
+  type        = string
+  description = "This block of addresses is allocated to Tanzu supervisor services for the cluster. You can use the default CIDR block (10.96.0.0/24) or pick another one, but a span of at least /24 is required."
+}
+
+variable "namespace_cidr" {
+  type        = string
+  description = "This block of addresses is allocated to namespace segments. It should have a span of at least /23 to provide adequate capacity for Tanzu Kubernetes Grid workloads in the cluster. Consider a span of /16 or /12."
+}


### PR DESCRIPTION
This PR adds an example on using Terraform and the Mastercard RestAPI provider to activate Tanzu service for a VMware Cloud on AWS SDDC

Signed-off-by: William Lam <wlam@vmware.com>